### PR TITLE
Fix removed REST_POSITION variable - Use piper_control.ArmOrientations.upright.rest_position instead

### DIFF
--- a/scripts/simple_move.py
+++ b/scripts/simple_move.py
@@ -60,7 +60,7 @@ def main():
       robot,
       kp_gains=5.0,
       kd_gains=0.8,
-      rest_position=piper_control.REST_POSITION,
+      rest_position=piper_control.ArmOrientations.upright.rest_position,
   ) as controller:
     print("moving to position ...")
     success = controller.move_to_position(

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -220,7 +220,7 @@
    "outputs": [],
    "source": [
     "# TODO(jscholz): Revisit the rest position.\n",
-    "robot.command_joint_positions(piper_control.REST_POSITION)"
+    "robot.command_joint_positions(piper_control.ArmOrientations.upright.rest_position)"
    ]
   },
   {
@@ -286,7 +286,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot0.command_joint_positions(piper_control.REST_POSITION)"
+    "robot0.command_joint_positions(piper_control.ArmOrientations.upright.rest_position)"
    ]
   },
   {
@@ -295,7 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot1.command_joint_positions(piper_control.REST_POSITION)"
+    "robot1.command_joint_positions(piper_control.ArmOrientations.upright.rest_position)"
    ]
   },
   {


### PR DESCRIPTION
Small fix to changes from https://github.com/Reimagine-Robotics/piper_control/pull/26/