### PR TITLE
Remove dynamic gain scaling in MIT joint position controller

### DIFF
--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -315,7 +315,9 @@ class MitJointPositionController(JointPositionController):
       if self._joint_flip_map:
         pos = -pos if self._joint_flip_map[ji] else pos
 
-      self._piper.command_joint_position_mit(ji, pos, kp_gains[ji], kd_gains[ji])
+      self._piper.command_joint_position_mit(
+          ji, pos, kp_gains[ji], kd_gains[ji]
+      )
 
   def relax_joints(self, timeout: float) -> None:
     """Relaxes joints, using MIT mode, over a number of seconds.


### PR DESCRIPTION
Simplifies the controller by using constant kp/kd gains directly
instead of scaling kp based on joint error distance.
