### PR TITLE
MIT controller: limit torque to prevent sign overflow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,4 +60,7 @@
         "**/*.egg-info": true
     },
     "git.ignoreLimitWarning": true,
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": [],
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,4 +48,8 @@ dev = [
   "jupyterlab>=4.4.5",
   "pre-commit>=4.2.0",
   "pylint>=3.3.8",
+  "pytest>=8.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -99,7 +99,7 @@ _POST_V1_7_3_MIT_JOINT_FLIP = [False, False, False, False, False, False]
 # Sending a magnitude greater than this saturates the field and, worse, causes
 # the torque *sign* to flip (integer overflow / wraparound in the encoding), so
 # we must hard-clip every commanded torque to this limit before sending.
-_MIT_TORQUE_LIMITS = [8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+MIT_TORQUE_LIMITS = [8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
 
 
 # Allowed gains range allowed for the Mit controller.
@@ -251,7 +251,7 @@ class MitJointPositionController(JointPositionController):
     # (commands are sent at _CONTROL_RATE). Instance state, not module state, so
     # concurrent controllers (e.g. two arms) don't suppress each other's
     # safety-critical overflow warnings.
-    self._torque_clip_warned = [False] * len(_MIT_TORQUE_LIMITS)
+    self._torque_clip_warned = [False] * len(MIT_TORQUE_LIMITS)
 
     if isinstance(kp_gains, float):
       self._kp_gains = (kp_gains,) * 6
@@ -293,7 +293,7 @@ class MitJointPositionController(JointPositionController):
   def _clip_torque(self, torque: float, joint_idx: int) -> float:
     """Clips a commanded torque to the CAN limit, warning if it was exceeded."""
 
-    limit = _MIT_TORQUE_LIMITS[joint_idx]
+    limit = MIT_TORQUE_LIMITS[joint_idx]
     clipped = float(np.clip(torque, -limit, limit))
     if clipped != torque:
       if not self._torque_clip_warned[joint_idx]:

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -291,8 +291,8 @@ class MitJointPositionController(JointPositionController):
     )
 
   def _clip_torque(self, torque: float, joint_idx: int) -> float:
-    """Clips a commanded torque to the CAN limit, warning if it was exceeded.
-    """
+    """Clips a commanded torque to the CAN limit, warning if it was exceeded."""
+    
     limit = _MIT_TORQUE_LIMITS[joint_idx]
     clipped = float(np.clip(torque, -limit, limit))
     if clipped != torque:

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -9,6 +9,7 @@ Piper robot. They provide two main benefits:
 
 import abc
 import dataclasses
+import logging as log
 import time
 from collections.abc import Sequence
 
@@ -94,7 +95,42 @@ _MIT_FLIP_FIX_VERSION = packaging_version.Version("1.7-3")
 _PRE_V1_7_3_MIT_JOINT_FLIP = [True, True, False, True, False, True]
 _POST_V1_7_3_MIT_JOINT_FLIP = [False, False, False, False, False, False]
 
-_MIT_TORQUE_LIMITS = [10.0, 10.0, 10.0, 10.0, 10.0, 10.0]
+# The MIT-mode torque command is packed into a CAN message with a limited range.
+# Sending a magnitude greater than this saturates the field and, worse, causes
+# the torque *sign* to flip (integer overflow / wraparound in the encoding), so
+# we must hard-clip every commanded torque to this limit before sending.
+_MIT_TORQUE_LIMITS = [8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
+
+# Tracks which joints are currently in a clipped state, so we warn only once per
+# excursion rather than every control tick (commands are sent at _CONTROL_RATE).
+_torque_clip_warned = [False] * len(_MIT_TORQUE_LIMITS)
+
+
+def _clip_torque(torque: float, joint_idx: int) -> float:
+  """Clips a commanded torque to the CAN limit, warning if it was exceeded.
+
+  Torques beyond ``_MIT_TORQUE_LIMITS`` overflow the CAN message field and cause
+  the torque sign to flip, so clipping here is a safety requirement, not just a
+  nicety. A single warning is logged when a joint first exceeds the limit; it is
+  not repeated every tick, and re-arms once the joint returns within limits.
+  """
+  limit = _MIT_TORQUE_LIMITS[joint_idx]
+  clipped = float(np.clip(torque, -limit, limit))
+  if clipped != torque:
+    if not _torque_clip_warned[joint_idx]:
+      log.warning(
+          "Commanded torque %.3f Nm for joint %d exceeds CAN limit of %.3f Nm; "
+          "clipping to %.3f Nm. Torques beyond the limit would overflow the "
+          "CAN message and flip sign.",
+          torque,
+          joint_idx,
+          limit,
+          clipped,
+      )
+      _torque_clip_warned[joint_idx] = True
+  else:
+    _torque_clip_warned[joint_idx] = False
+  return clipped
 
 # Allowed gains range allowed for the Mit controller.
 _MAX_KP_GAIN = 100.0
@@ -329,9 +365,7 @@ class MitJointPositionController(JointPositionController):
       torque_ff = torques_ff[ji]
       if self._joint_flip_map:
         torque_ff = -torque_ff if self._joint_flip_map[ji] else torque_ff
-      torque_ff = np.clip(
-          torque_ff, -_MIT_TORQUE_LIMITS[ji], _MIT_TORQUE_LIMITS[ji]
-      )
+      torque_ff = _clip_torque(torque_ff, ji)
 
       velocity = velocities[ji]
       if self._joint_flip_map:
@@ -375,9 +409,7 @@ class MitJointPositionController(JointPositionController):
       if torque is not None:
         if self._joint_flip_map:
           torque = -torque if self._joint_flip_map[ji] else torque
-        torque = np.clip(
-            torque, -_MIT_TORQUE_LIMITS[ji], _MIT_TORQUE_LIMITS[ji]
-        )
+        torque = _clip_torque(torque, ji)
 
         self._piper.command_joint_torque_mit(ji, torque)
 

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -290,6 +290,27 @@ class MitJointPositionController(JointPositionController):
         move_mode=pi.MoveMode.MIT,
     )
 
+  def _validate_torques_finite(self, torques: Sequence[float | None]) -> None:
+    """Rejects a torque command containing any NaN before anything is sent.
+
+    A NaN torque cannot be meaningfully clipped and would cause undefined
+    hardware behaviour. Because commands are dispatched joint-by-joint, a NaN
+    discovered mid-loop would leave earlier joints already commanded and the arm
+    in a partially-commanded state. Validating the whole vector up front gives
+    all-or-nothing semantics: either every joint is commanded or none is.
+
+    ``None`` entries are skipped (they mean "leave this joint uncommanded").
+    """
+    bad = [
+        ji
+        for ji, t in enumerate(torques)
+        if t is not None and np.isnan(t)
+    ]
+    if bad:
+      raise ValueError(
+          f"Commanded torque for joint(s) {bad} is NaN; refusing to send any."
+      )
+
   def _clip_torque(self, torque: float, joint_idx: int) -> float:
     """Clips a commanded torque to the CAN limit, warning if it was exceeded.
 
@@ -299,15 +320,10 @@ class MitJointPositionController(JointPositionController):
     limit; it is not repeated every tick, and re-arms once the joint returns
     within limits.
 
-    A NaN torque cannot be meaningfully clipped and would cause undefined
-    hardware behaviour, so it is rejected outright rather than routed through
-    the clip path (where ``NaN != NaN`` would masquerade as an ordinary clip).
+    Callers must reject NaN inputs up front (see ``_validate_torques_finite``);
+    a NaN reaching this method would slip through the clip path as an ordinary
+    clip because ``NaN != NaN``.
     """
-    if np.isnan(torque):
-      raise ValueError(
-          f"Commanded torque for joint {joint_idx} is NaN; refusing to send."
-      )
-
     limit = _MIT_TORQUE_LIMITS[joint_idx]
     clipped = float(np.clip(torque, -limit, limit))
     if clipped != torque:
@@ -364,6 +380,10 @@ class MitJointPositionController(JointPositionController):
     assert len(torques_ff) == 6
     assert len(velocities) == 6
 
+    # Validate the whole torque vector before commanding any joint, so a NaN in
+    # one joint doesn't leave earlier joints already commanded (all-or-nothing).
+    self._validate_torques_finite(torques_ff)
+
     for ji, pos in enumerate(target):
 
       # Clip the position to limits so that we don't send invalid commands.
@@ -417,6 +437,10 @@ class MitJointPositionController(JointPositionController):
       torques: Sequence[float | None],
   ) -> None:
     assert len(torques) == 6
+
+    # Validate the whole torque vector before commanding any joint, so a NaN in
+    # one joint doesn't leave earlier joints already commanded (all-or-nothing).
+    self._validate_torques_finite(torques)
 
     for ji, torque in enumerate(torques):
       if torque is not None:

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -101,36 +101,6 @@ _POST_V1_7_3_MIT_JOINT_FLIP = [False, False, False, False, False, False]
 # we must hard-clip every commanded torque to this limit before sending.
 _MIT_TORQUE_LIMITS = [8.0, 8.0, 8.0, 8.0, 8.0, 8.0]
 
-# Tracks which joints are currently in a clipped state, so we warn only once per
-# excursion rather than every control tick (commands are sent at _CONTROL_RATE).
-_torque_clip_warned = [False] * len(_MIT_TORQUE_LIMITS)
-
-
-def _clip_torque(torque: float, joint_idx: int) -> float:
-  """Clips a commanded torque to the CAN limit, warning if it was exceeded.
-
-  Torques beyond ``_MIT_TORQUE_LIMITS`` overflow the CAN message field and cause
-  the torque sign to flip, so clipping here is a safety requirement, not just a
-  nicety. A single warning is logged when a joint first exceeds the limit; it is
-  not repeated every tick, and re-arms once the joint returns within limits.
-  """
-  limit = _MIT_TORQUE_LIMITS[joint_idx]
-  clipped = float(np.clip(torque, -limit, limit))
-  if clipped != torque:
-    if not _torque_clip_warned[joint_idx]:
-      log.warning(
-          "Commanded torque %.3f Nm for joint %d exceeds CAN limit of %.3f Nm; "
-          "clipping to %.3f Nm. Torques beyond the limit would overflow the "
-          "CAN message and flip sign.",
-          torque,
-          joint_idx,
-          limit,
-          clipped,
-      )
-      _torque_clip_warned[joint_idx] = True
-  else:
-    _torque_clip_warned[joint_idx] = False
-  return clipped
 
 # Allowed gains range allowed for the Mit controller.
 _MAX_KP_GAIN = 100.0
@@ -276,6 +246,13 @@ class MitJointPositionController(JointPositionController):
 
     super().__init__(piper)
 
+    # Per-joint latch tracking whether a joint is currently in a clipped state,
+    # so we warn only once per excursion rather than every control tick
+    # (commands are sent at _CONTROL_RATE). Instance state, not module state, so
+    # concurrent controllers (e.g. two arms) don't suppress each other's
+    # safety-critical overflow warnings.
+    self._torque_clip_warned = [False] * len(_MIT_TORQUE_LIMITS)
+
     if isinstance(kp_gains, float):
       self._kp_gains = (kp_gains,) * 6
     else:
@@ -312,6 +289,42 @@ class MitJointPositionController(JointPositionController):
         arm_controller=pi.ArmController.MIT,
         move_mode=pi.MoveMode.MIT,
     )
+
+  def _clip_torque(self, torque: float, joint_idx: int) -> float:
+    """Clips a commanded torque to the CAN limit, warning if it was exceeded.
+
+    Torques beyond ``_MIT_TORQUE_LIMITS`` overflow the CAN message field and
+    cause the torque sign to flip, so clipping here is a safety requirement, not
+    just a nicety. A single warning is logged when a joint first exceeds the
+    limit; it is not repeated every tick, and re-arms once the joint returns
+    within limits.
+
+    A NaN torque cannot be meaningfully clipped and would cause undefined
+    hardware behaviour, so it is rejected outright rather than routed through
+    the clip path (where ``NaN != NaN`` would masquerade as an ordinary clip).
+    """
+    if np.isnan(torque):
+      raise ValueError(
+          f"Commanded torque for joint {joint_idx} is NaN; refusing to send."
+      )
+
+    limit = _MIT_TORQUE_LIMITS[joint_idx]
+    clipped = float(np.clip(torque, -limit, limit))
+    if clipped != torque:
+      if not self._torque_clip_warned[joint_idx]:
+        log.warning(
+            "Commanded torque %.3f Nm for joint %d exceeds CAN limit of %.3f "
+            "Nm; clipping to %.3f Nm. Torques beyond the limit would overflow "
+            "the CAN message and flip sign.",
+            torque,
+            joint_idx,
+            limit,
+            clipped,
+        )
+        self._torque_clip_warned[joint_idx] = True
+    else:
+      self._torque_clip_warned[joint_idx] = False
+    return clipped
 
   def stop(self) -> None:
     # Move to the rest position if one is specified.
@@ -365,7 +378,7 @@ class MitJointPositionController(JointPositionController):
       torque_ff = torques_ff[ji]
       if self._joint_flip_map:
         torque_ff = -torque_ff if self._joint_flip_map[ji] else torque_ff
-      torque_ff = _clip_torque(torque_ff, ji)
+      torque_ff = self._clip_torque(torque_ff, ji)
 
       velocity = velocities[ji]
       if self._joint_flip_map:
@@ -409,7 +422,7 @@ class MitJointPositionController(JointPositionController):
       if torque is not None:
         if self._joint_flip_map:
           torque = -torque if self._joint_flip_map[ji] else torque
-        torque = _clip_torque(torque, ji)
+        torque = self._clip_torque(torque, ji)
 
         self._piper.command_joint_torque_mit(ji, torque)
 

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -292,7 +292,7 @@ class MitJointPositionController(JointPositionController):
 
   def _clip_torque(self, torque: float, joint_idx: int) -> float:
     """Clips a commanded torque to the CAN limit, warning if it was exceeded."""
-    
+
     limit = _MIT_TORQUE_LIMITS[joint_idx]
     clipped = float(np.clip(torque, -limit, limit))
     if clipped != torque:

--- a/src/piper_control/piper_control.py
+++ b/src/piper_control/piper_control.py
@@ -290,39 +290,8 @@ class MitJointPositionController(JointPositionController):
         move_mode=pi.MoveMode.MIT,
     )
 
-  def _validate_torques_finite(self, torques: Sequence[float | None]) -> None:
-    """Rejects a torque command containing any NaN before anything is sent.
-
-    A NaN torque cannot be meaningfully clipped and would cause undefined
-    hardware behaviour. Because commands are dispatched joint-by-joint, a NaN
-    discovered mid-loop would leave earlier joints already commanded and the arm
-    in a partially-commanded state. Validating the whole vector up front gives
-    all-or-nothing semantics: either every joint is commanded or none is.
-
-    ``None`` entries are skipped (they mean "leave this joint uncommanded").
-    """
-    bad = [
-        ji
-        for ji, t in enumerate(torques)
-        if t is not None and np.isnan(t)
-    ]
-    if bad:
-      raise ValueError(
-          f"Commanded torque for joint(s) {bad} is NaN; refusing to send any."
-      )
-
   def _clip_torque(self, torque: float, joint_idx: int) -> float:
     """Clips a commanded torque to the CAN limit, warning if it was exceeded.
-
-    Torques beyond ``_MIT_TORQUE_LIMITS`` overflow the CAN message field and
-    cause the torque sign to flip, so clipping here is a safety requirement, not
-    just a nicety. A single warning is logged when a joint first exceeds the
-    limit; it is not repeated every tick, and re-arms once the joint returns
-    within limits.
-
-    Callers must reject NaN inputs up front (see ``_validate_torques_finite``);
-    a NaN reaching this method would slip through the clip path as an ordinary
-    clip because ``NaN != NaN``.
     """
     limit = _MIT_TORQUE_LIMITS[joint_idx]
     clipped = float(np.clip(torque, -limit, limit))
@@ -380,10 +349,6 @@ class MitJointPositionController(JointPositionController):
     assert len(torques_ff) == 6
     assert len(velocities) == 6
 
-    # Validate the whole torque vector before commanding any joint, so a NaN in
-    # one joint doesn't leave earlier joints already commanded (all-or-nothing).
-    self._validate_torques_finite(torques_ff)
-
     for ji, pos in enumerate(target):
 
       # Clip the position to limits so that we don't send invalid commands.
@@ -437,10 +402,6 @@ class MitJointPositionController(JointPositionController):
       torques: Sequence[float | None],
   ) -> None:
     assert len(torques) == 6
-
-    # Validate the whole torque vector before commanding any joint, so a NaN in
-    # one joint doesn't leave earlier joints already commanded (all-or-nothing).
-    self._validate_torques_finite(torques)
 
     for ji, torque in enumerate(torques):
       if torque is not None:

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -1,9 +1,16 @@
-"""Tests for CAN torque clipping in piper_control.
+"""Tests for CAN torque clipping in MitJointPositionController.
 
 Torques beyond the CAN message limit overflow the field and flip sign, so
 ``_clip_torque`` hard-clips every commanded torque and warns (once per
-excursion) when it does. These tests pin that behaviour; the function is pure
-and hardware-free, so no arm is required.
+excursion) when it does. NaN torques are rejected outright. These tests pin
+that behaviour; the method is pure aside from its per-instance warn latch and
+needs no arm, so instances are built without running __init__ (which would talk
+to hardware).
+
+Run with plugin autoload disabled to avoid unrelated system pytest plugins
+(e.g. a ROS install on the PYTHONPATH) failing to import:
+
+    PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest
 """
 
 import logging
@@ -13,11 +20,15 @@ import pytest
 from piper_control import piper_control as pc
 
 
-@pytest.fixture(autouse=True)
-def _reset_warn_state():
-  """Reset the module-level warn-latch so tests don't leak state into others."""
-  pc._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
-  yield
+def _make_controller():
+  """Build a controller with just the state _clip_torque needs.
+
+  ``__init__`` queries the arm's firmware over the wire, so we bypass it and set
+  only the per-instance warn latch the method reads and writes.
+  """
+  controller = pc.MitJointPositionController.__new__(pc.MitJointPositionController)
+  controller._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
+  return controller
 
 
 def test_can_limit_is_8nm():
@@ -26,50 +37,76 @@ def test_can_limit_is_8nm():
 
 
 def test_in_range_torque_is_unchanged():
-  assert pc._clip_torque(5.0, 0) == 5.0
-  assert pc._clip_torque(-8.0, 3) == -8.0
-  assert pc._clip_torque(0.0, 5) == 0.0
+  c = _make_controller()
+  assert c._clip_torque(5.0, 0) == 5.0
+  assert c._clip_torque(-8.0, 3) == -8.0
+  assert c._clip_torque(0.0, 5) == 0.0
 
 
 def test_over_limit_is_clipped_to_limit():
-  assert pc._clip_torque(12.0, 0) == 8.0
-  assert pc._clip_torque(-100.0, 2) == -8.0
+  c = _make_controller()
+  assert c._clip_torque(12.0, 0) == 8.0
+  assert c._clip_torque(-100.0, 2) == -8.0
+
+
+def test_nan_torque_is_rejected():
+  c = _make_controller()
+  with pytest.raises(ValueError, match="NaN"):
+    c._clip_torque(float("nan"), 4)
+  # A NaN must not silently latch the warn state as if it were a clip.
+  assert c._torque_clip_warned[4] is False
 
 
 def test_warns_when_clipping(caplog):
+  c = _make_controller()
   with caplog.at_level(logging.WARNING):
-    pc._clip_torque(12.0, 1)
+    c._clip_torque(12.0, 1)
   warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
   assert len(warnings) == 1
   assert "joint 1" in warnings[0].getMessage()
 
 
 def test_does_not_warn_in_range(caplog):
+  c = _make_controller()
   with caplog.at_level(logging.WARNING):
-    pc._clip_torque(5.0, 0)
+    c._clip_torque(5.0, 0)
   assert not caplog.records
 
 
 def test_warns_once_per_excursion(caplog):
   # Simulate a sustained over-limit command at the control rate: only the first
   # tick should warn.
+  c = _make_controller()
   with caplog.at_level(logging.WARNING):
     for _ in range(200):
-      pc._clip_torque(12.0, 0)
+      c._clip_torque(12.0, 0)
   assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
 
 
 def test_rearms_after_returning_in_range(caplog):
+  c = _make_controller()
   with caplog.at_level(logging.WARNING):
-    pc._clip_torque(12.0, 0)  # first excursion -> warns
-    pc._clip_torque(5.0, 0)  # back in range -> re-arms
-    pc._clip_torque(12.0, 0)  # new excursion -> warns again
+    c._clip_torque(12.0, 0)  # first excursion -> warns
+    c._clip_torque(5.0, 0)  # back in range -> re-arms
+    c._clip_torque(12.0, 0)  # new excursion -> warns again
   assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
 
 
 def test_per_joint_warn_state_is_independent(caplog):
+  c = _make_controller()
   with caplog.at_level(logging.WARNING):
-    pc._clip_torque(12.0, 0)
-    pc._clip_torque(12.0, 1)
+    c._clip_torque(12.0, 0)
+    c._clip_torque(12.0, 1)
   # Both joints warn on their own first excursion.
+  assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
+
+
+def test_instances_do_not_share_warn_state(caplog):
+  # Two controllers (e.g. two arms) must not suppress each other's first
+  # warning — the latch is per-instance.
+  a = _make_controller()
+  b = _make_controller()
+  with caplog.at_level(logging.WARNING):
+    a._clip_torque(12.0, 0)  # latches on instance a
+    b._clip_torque(12.0, 0)  # instance b must still warn
   assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -2,10 +2,9 @@
 
 Torques beyond the CAN message limit overflow the field and flip sign, so
 ``_clip_torque`` hard-clips every commanded torque and warns (once per
-excursion) when it does. NaN torques are rejected up front by
-``_validate_torques_finite`` so a bad joint can't leave the arm partially
-commanded. These tests pin that behaviour; the methods need no arm, so
-instances are built without running __init__ (which would talk to hardware).
+excursion) when it does. These tests pin that behaviour; the method needs no
+arm, so instances are built without running __init__ (which would talk to
+hardware).
 
 Run with plugin autoload disabled to avoid unrelated system pytest plugins
 (e.g. a ROS install on the PYTHONPATH) failing to import:
@@ -15,7 +14,6 @@ Run with plugin autoload disabled to avoid unrelated system pytest plugins
 
 import logging
 
-import pytest
 from piper_control import piper_control as pc
 
 
@@ -48,67 +46,6 @@ def test_over_limit_is_clipped_to_limit():
   c = _make_controller()
   assert c._clip_torque(12.0, 0) == 8.0
   assert c._clip_torque(-100.0, 2) == -8.0
-
-
-def test_validate_torques_finite_rejects_nan():
-  c = _make_controller()
-  with pytest.raises(ValueError, match="NaN"):
-    c._validate_torques_finite([0.0, 0.0, 0.0, 0.0, float("nan"), 0.0])
-
-
-def test_validate_torques_finite_reports_all_bad_joints():
-  c = _make_controller()
-  nan = float("nan")
-  with pytest.raises(ValueError, match=r"\[1, 4\]"):
-    c._validate_torques_finite([0.0, nan, 0.0, 0.0, nan, 0.0])
-
-
-def test_validate_torques_finite_allows_finite_and_none():
-  c = _make_controller()
-  # None means "leave this joint uncommanded" and must be tolerated.
-  c._validate_torques_finite([0.0, None, -3.0, 100.0, None, 8.0])
-
-
-class _RecordingPiper:
-  """Minimal fake that records which joints were commanded."""
-
-  def __init__(self):
-    self.torque_calls = []
-
-  def command_joint_torque_mit(self, joint_idx, torque):
-    self.torque_calls.append((joint_idx, torque))
-
-  def command_joint_position_mit(self, **kwargs):
-    self.torque_calls.append(kwargs)
-
-
-def test_command_torques_is_all_or_nothing_on_nan():
-  # A NaN at joint 4 must abort before joint 0 is ever commanded, rather than
-  # leaving joints 0-3 commanded and the arm partially updated.
-  c = _make_controller()
-  c._joint_flip_map = pc._POST_V1_7_3_MIT_JOINT_FLIP
-  fake = _RecordingPiper()
-  c._piper = fake
-  with pytest.raises(ValueError, match="NaN"):
-    c.command_torques([1.0, 1.0, 1.0, 1.0, float("nan"), 1.0])
-  assert fake.torque_calls == []  # nothing sent
-
-
-def test_command_joints_is_all_or_nothing_on_nan_torque_ff():
-  # Same guarantee for the feed-forward torque path in command_joints: a NaN
-  # torque_ff must abort before any joint position command is sent.
-  c = _make_controller()
-  c._joint_flip_map = pc._POST_V1_7_3_MIT_JOINT_FLIP
-  c._kp_gains = (1.0,) * 6
-  c._kd_gains = (1.0,) * 6
-  fake = _RecordingPiper()
-  c._piper = fake
-  with pytest.raises(ValueError, match="NaN"):
-    c.command_joints(
-        target=[0.0] * 6,
-        torques_ff=[1.0, 1.0, float("nan"), 1.0, 1.0, 1.0],
-    )
-  assert fake.torque_calls == []  # nothing sent
 
 
 def test_warns_when_clipping(caplog):

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -16,7 +16,6 @@ Run with plugin autoload disabled to avoid unrelated system pytest plugins
 import logging
 
 import pytest
-
 from piper_control import piper_control as pc
 
 
@@ -26,7 +25,9 @@ def _make_controller():
   ``__init__`` queries the arm's firmware over the wire, so we bypass it and set
   only the per-instance warn latch the method reads and writes.
   """
-  controller = pc.MitJointPositionController.__new__(pc.MitJointPositionController)
+  controller = pc.MitJointPositionController.__new__(
+    pc.MitJointPositionController
+  )
   controller._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
   return controller
 

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -2,10 +2,10 @@
 
 Torques beyond the CAN message limit overflow the field and flip sign, so
 ``_clip_torque`` hard-clips every commanded torque and warns (once per
-excursion) when it does. NaN torques are rejected outright. These tests pin
-that behaviour; the method is pure aside from its per-instance warn latch and
-needs no arm, so instances are built without running __init__ (which would talk
-to hardware).
+excursion) when it does. NaN torques are rejected up front by
+``_validate_torques_finite`` so a bad joint can't leave the arm partially
+commanded. These tests pin that behaviour; the methods need no arm, so
+instances are built without running __init__ (which would talk to hardware).
 
 Run with plugin autoload disabled to avoid unrelated system pytest plugins
 (e.g. a ROS install on the PYTHONPATH) failing to import:
@@ -26,7 +26,7 @@ def _make_controller():
   only the per-instance warn latch the method reads and writes.
   """
   controller = pc.MitJointPositionController.__new__(
-    pc.MitJointPositionController
+      pc.MitJointPositionController
   )
   controller._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
   return controller
@@ -50,12 +50,65 @@ def test_over_limit_is_clipped_to_limit():
   assert c._clip_torque(-100.0, 2) == -8.0
 
 
-def test_nan_torque_is_rejected():
+def test_validate_torques_finite_rejects_nan():
   c = _make_controller()
   with pytest.raises(ValueError, match="NaN"):
-    c._clip_torque(float("nan"), 4)
-  # A NaN must not silently latch the warn state as if it were a clip.
-  assert c._torque_clip_warned[4] is False
+    c._validate_torques_finite([0.0, 0.0, 0.0, 0.0, float("nan"), 0.0])
+
+
+def test_validate_torques_finite_reports_all_bad_joints():
+  c = _make_controller()
+  nan = float("nan")
+  with pytest.raises(ValueError, match=r"\[1, 4\]"):
+    c._validate_torques_finite([0.0, nan, 0.0, 0.0, nan, 0.0])
+
+
+def test_validate_torques_finite_allows_finite_and_none():
+  c = _make_controller()
+  # None means "leave this joint uncommanded" and must be tolerated.
+  c._validate_torques_finite([0.0, None, -3.0, 100.0, None, 8.0])
+
+
+class _RecordingPiper:
+  """Minimal fake that records which joints were commanded."""
+
+  def __init__(self):
+    self.torque_calls = []
+
+  def command_joint_torque_mit(self, joint_idx, torque):
+    self.torque_calls.append((joint_idx, torque))
+
+  def command_joint_position_mit(self, **kwargs):
+    self.torque_calls.append(kwargs)
+
+
+def test_command_torques_is_all_or_nothing_on_nan():
+  # A NaN at joint 4 must abort before joint 0 is ever commanded, rather than
+  # leaving joints 0-3 commanded and the arm partially updated.
+  c = _make_controller()
+  c._joint_flip_map = pc._POST_V1_7_3_MIT_JOINT_FLIP
+  fake = _RecordingPiper()
+  c._piper = fake
+  with pytest.raises(ValueError, match="NaN"):
+    c.command_torques([1.0, 1.0, 1.0, 1.0, float("nan"), 1.0])
+  assert fake.torque_calls == []  # nothing sent
+
+
+def test_command_joints_is_all_or_nothing_on_nan_torque_ff():
+  # Same guarantee for the feed-forward torque path in command_joints: a NaN
+  # torque_ff must abort before any joint position command is sent.
+  c = _make_controller()
+  c._joint_flip_map = pc._POST_V1_7_3_MIT_JOINT_FLIP
+  c._kp_gains = (1.0,) * 6
+  c._kd_gains = (1.0,) * 6
+  fake = _RecordingPiper()
+  c._piper = fake
+  with pytest.raises(ValueError, match="NaN"):
+    c.command_joints(
+        target=[0.0] * 6,
+        torques_ff=[1.0, 1.0, float("nan"), 1.0, 1.0, 1.0],
+    )
+  assert fake.torque_calls == []  # nothing sent
 
 
 def test_warns_when_clipping(caplog):

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -26,13 +26,13 @@ def _make_controller():
   controller = pc.MitJointPositionController.__new__(
       pc.MitJointPositionController
   )
-  controller._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
+  controller._torque_clip_warned = [False] * len(pc.MIT_TORQUE_LIMITS)
   return controller
 
 
 def test_can_limit_is_8nm():
   # The CAN field saturates at 8 Nm; a higher limit would let the sign flip.
-  assert pc._MIT_TORQUE_LIMITS == [8.0] * 6
+  assert pc.MIT_TORQUE_LIMITS == [8.0] * 6
 
 
 def test_in_range_torque_is_unchanged():

--- a/tests/test_clip_torque.py
+++ b/tests/test_clip_torque.py
@@ -1,0 +1,75 @@
+"""Tests for CAN torque clipping in piper_control.
+
+Torques beyond the CAN message limit overflow the field and flip sign, so
+``_clip_torque`` hard-clips every commanded torque and warns (once per
+excursion) when it does. These tests pin that behaviour; the function is pure
+and hardware-free, so no arm is required.
+"""
+
+import logging
+
+import pytest
+
+from piper_control import piper_control as pc
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_state():
+  """Reset the module-level warn-latch so tests don't leak state into others."""
+  pc._torque_clip_warned = [False] * len(pc._MIT_TORQUE_LIMITS)
+  yield
+
+
+def test_can_limit_is_8nm():
+  # The CAN field saturates at 8 Nm; a higher limit would let the sign flip.
+  assert pc._MIT_TORQUE_LIMITS == [8.0] * 6
+
+
+def test_in_range_torque_is_unchanged():
+  assert pc._clip_torque(5.0, 0) == 5.0
+  assert pc._clip_torque(-8.0, 3) == -8.0
+  assert pc._clip_torque(0.0, 5) == 0.0
+
+
+def test_over_limit_is_clipped_to_limit():
+  assert pc._clip_torque(12.0, 0) == 8.0
+  assert pc._clip_torque(-100.0, 2) == -8.0
+
+
+def test_warns_when_clipping(caplog):
+  with caplog.at_level(logging.WARNING):
+    pc._clip_torque(12.0, 1)
+  warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+  assert len(warnings) == 1
+  assert "joint 1" in warnings[0].getMessage()
+
+
+def test_does_not_warn_in_range(caplog):
+  with caplog.at_level(logging.WARNING):
+    pc._clip_torque(5.0, 0)
+  assert not caplog.records
+
+
+def test_warns_once_per_excursion(caplog):
+  # Simulate a sustained over-limit command at the control rate: only the first
+  # tick should warn.
+  with caplog.at_level(logging.WARNING):
+    for _ in range(200):
+      pc._clip_torque(12.0, 0)
+  assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+def test_rearms_after_returning_in_range(caplog):
+  with caplog.at_level(logging.WARNING):
+    pc._clip_torque(12.0, 0)  # first excursion -> warns
+    pc._clip_torque(5.0, 0)  # back in range -> re-arms
+    pc._clip_torque(12.0, 0)  # new excursion -> warns again
+  assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2
+
+
+def test_per_joint_warn_state_is_independent(caplog):
+  with caplog.at_level(logging.WARNING):
+    pc._clip_torque(12.0, 0)
+    pc._clip_torque(12.0, 1)
+  # Both joints warn on their own first excursion.
+  assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -527,6 +527,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload-time = "2026-01-28T05:58:03.517Z" },
     { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload-time = "2026-01-28T05:58:05.649Z" },
     { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload-time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload-time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload-time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload-time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload-time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload-time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
 ]
 
 [[package]]
@@ -591,6 +599,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/8c/f834fbf984f691b4f7ff60f50b514cc3de5cc08abfc3295564dd89c5e2e7/importlib_resources-6.5.2.tar.gz", hash = "sha256:185f87adef5bcc288449d98fb4fba07cea78bc036455dd44c5fc4a2fe78fed2c", size = 44693, upload-time = "2025-01-03T18:51:56.698Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/ed/1f1afb2e9e7f38a545d628f864d562a5ae64fe6f7a10e28ffb9b185b4e89/importlib_resources-6.5.2-py3-none-any.whl", hash = "sha256:789cfdc3ed28c78b67a06acb8126751ced69a3d5f79c095a98298cd8a760ccec", size = 37461, upload-time = "2025-01-03T18:51:54.306Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1262,6 +1279,7 @@ dev = [
     { name = "jupyterlab" },
     { name = "pre-commit" },
     { name = "pylint" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -1279,6 +1297,7 @@ dev = [
     { name = "jupyterlab", specifier = ">=4.4.5" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pylint", specifier = ">=3.3.8" },
+    { name = "pytest", specifier = ">=8.0.0" },
 ]
 
 [[package]]
@@ -1300,6 +1319,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1416,6 +1444,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/16/912b7225d56284859cd9a672827f18be43f8012f8b7b932bc4bd959a298e/pyopengl-3.1.10.tar.gz", hash = "sha256:c4a02d6866b54eb119c8e9b3fb04fa835a95ab802dd96607ab4cdb0012df8335", size = 1915580, upload-time = "2025-08-18T02:33:01.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl", hash = "sha256:794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f", size = 3194996, upload-time = "2025-08-18T02:32:59.902Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The arm torques will sign flip after 8nm due to CAN encoding issues, this clips them and adds a warning