### PR TITLE
Wait for the motors to switch off in disable_arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+-   `disable_arm` returns once the joint motors have actually switched off
+    rather than once the arm reports `STANDBY`. The motors cut out ~730ms after
+    the reset, so it previously returned while they were still powered, and a
+    caller enabling the arm inside that window saw it as powered, reported
+    success, and then had the motors drop out underneath it. It now blocks for
+    ~0.9s rather than ~0.1s, which the default 10s `timeout_seconds`
+    accommodates comfortably; only a caller overriding that below ~1s would
+    now time out.
+
 ## [1.5.0]
 
 -   Only support direct gravity compensation mode.

--- a/src/piper_control/piper_init.py
+++ b/src/piper_control/piper_init.py
@@ -12,6 +12,14 @@ from piper_control import piper_interface as pi
 _SHORT_WAIT = 0.1
 _LONG_WAIT = 0.5
 
+# Minimum gap between resets, comfortably past the motors-off delay below:
+# re-sending while the motors are still cutting out restarts the wait.
+_MIN_RESET_INTERVAL_SEC = 2.0
+
+# The six motor frames are cached separately, so hold the reading rather than
+# trusting a single poll.
+_MOTORS_OFF_CONFIRM_SEC = 0.2
+
 
 def _create_timeout(
     seconds: float,
@@ -82,6 +90,16 @@ def reset_gripper(
   enable_gripper(piper, timeout_seconds=timeout_seconds)
 
 
+def _is_arm_off(piper: pi.PiperInterface) -> bool:
+  """Whether the arm is in a clean, powered-down state right now."""
+  return (
+      piper.control_mode == pi.ControlMode.STANDBY
+      and piper.arm_status == pi.ArmStatus.NORMAL
+      and piper.teach_status == pi.TeachStatus.OFF
+      and not piper.is_arm_enabled()
+  )
+
+
 def disable_arm(
     piper: pi.PiperInterface,
     *,
@@ -90,22 +108,29 @@ def disable_arm(
   """
   Disables the arm.
 
+  Returns once the joint motors have actually switched off, not merely once the
+  arm reports STANDBY: the arm reports STANDBY within ~20ms of the reset but its
+  motors only cut out 722-730ms later (measured across 20 resets).
+
   WARNING: This powers down the arm and it will drop if not supported.
   """
   timeout_trigger = _create_timeout(timeout_seconds, "disable_arm")
+  off_since: float | None = None
+  last_reset = 0.0
   while True:
-    piper.set_emergency_stop(pi.EmergencyStop.RESUME)
-    time.sleep(_SHORT_WAIT)
-
-    if (
-        piper.control_mode == pi.ControlMode.STANDBY
-        and piper.arm_status == pi.ArmStatus.NORMAL
-        and piper.teach_status == pi.TeachStatus.OFF
-    ):
-      break
+    if _is_arm_off(piper):
+      if off_since is None:
+        off_since = time.time()
+      elif time.time() - off_since >= _MOTORS_OFF_CONFIRM_SEC:
+        return
+    else:
+      off_since = None
+      if time.time() - last_reset >= _MIN_RESET_INTERVAL_SEC:
+        piper.set_emergency_stop(pi.EmergencyStop.RESUME)
+        last_reset = time.time()
 
     timeout_trigger()
-    time.sleep(_LONG_WAIT)
+    time.sleep(_SHORT_WAIT)
 
 
 def enable_arm(


### PR DESCRIPTION
Fixes an arm that ends up powered down while every layer above it reports
success. This meant that sometimes a cycle from STOP -> READY left the arm
in a limp state instead of stiffening again.

## The bug

`disable_arm` returned as soon as the arm reported `STANDBY`. Measured across
20 resets, the arm reports `STANDBY` within ~20 ms but its joint motors only
switch off **722-730 ms later** (median 727 ms, an 8 ms spread — it looks like a
fixed firmware delay).

So there is a ~0.7 s window in which the arm claims to be down while its motors
are still powered. A caller that enables the arm inside that window sees
`driver_enable_status` still set, `is_arm_enabled()` returns True, `enable_arm`
reports success — and the motors then drop out with nothing re-checking. The arm
is left powered down, holding nothing, while the enable reported success.

Reproduced on hardware from a robot SDK doing a quick stop-then-resume: the arm
went limp with all joint efforts at zero while the SDK reported READY, and
recovery required a further full disable/enable cycle.

## The fix

`disable_arm` now returns once the joint motors have actually switched off,
checked against `driver_enable_status` rather than the status frame alone.

The reset is paced by its own interval rather than re-sent on every retry,
because re-sending while the motors are still cutting out restarts the wait.

`_MOTORS_OFF_CONFIRM_SEC` requires the reading to hold rather than trusting a
single poll, since the six per-motor frames are cached separately.

## Results

Rapid stop-then-resume cycles ~1.2 s apart, on an arm with an actuating V2
gripper:

| | before | after |
|---|---|---|
| cycles passed | 1 of 3 | **16 of 16** |
| stop → motors off | ~4.3 s | 5.26 s |
| resume → motors on | 0.71 s | 1.63 s |

`disable_arm` costs ~0.9 s more, which is the motor-off delay it now waits out.

The resume getting *longer* is the fix working: the enable previously exited on
its first sample, frequently mid-transient, which was the bug. The motors are
now genuinely off when it starts, so it takes one further iteration to confirm
them back on — matching the timing already seen on slow cycles, which always
worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
